### PR TITLE
ci(release-please): Use googleapis/release-please-action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
   pull-request:
     runs-on: ubuntu-24.04
     steps:
-    - uses: google-github-actions/release-please-action@v4
+    - uses: googleapis/release-please-action@v4
       id: release
       with:
         token: ${{secrets.GH_OPENUI5BOT}}


### PR DESCRIPTION
`google-github-actions/release-please-action` is deprecated.