### PR TITLE
fix(openui5_lts): Result when determining LTS releases is aligned with Renovate schema

### DIFF
--- a/datasources.json
+++ b/datasources.json
@@ -4,13 +4,13 @@
         "openui5": {
             "defaultRegistryUrlTemplate": "https://sdk.openui5.org/version.json",
             "transformTemplates": [
-                "{ \"releases\": $distinct($each($, function($value){ return { \"version\": $value.version, \"changelogUrl\": $value.('https://sdk.openui5.org/' & version & '/#releasenotes.html'), \"sourceUrl\": $value.('https://github.com/SAP/openui5/tree/' & version & '/') }})), \"homepage\": \"https://sdk.openui5.org/\", \"changelogUrl\": \"https://sdk.openui5.org/#releasenotes.html\", \"sourceUrl\": \"https://github.com/SAP/openui5\"}"
+                "{ \"releases\": $distinct($each($, function($value){ return { \"version\": $value.version, \"changelogUrl\": $value.('https://sdk.openui5.org/' & version & '/#releasenotes.html'), \"sourceUrl\": $value.('https://github.com/SAP/openui5/tree/' & version & '/') }})), \"homepage\": \"https://sdk.openui5.org/\", \"changelogUrl\": \"https://sdk.openui5.org/#releasenotes.html\", \"sourceUrl\": \"https://github.com/SAP/openui5\" }"
             ]
         },
         "openui5_lts": {
             "defaultRegistryUrlTemplate": "https://sdk.openui5.org/version.json",
             "transformTemplates": [
-                "{ \"releases\": $distinct($filter($each($, function($value){ return { \"version\": $value.version, \"isStable\": $value.lts, \"changelogUrl\": $value.('https://sdk.openui5.org/' & version & '/#releasenotes.html', \"sourceUrl\": $value.('https://github.com/SAP/openui5/tree/' & version & '/'))}}), function($f){$f.isStable})), \"homepage\": \"https://sdk.openui5.org/\", \"changelogUrl\": \"https://sdk.openui5.org/#releasenotes.html\", \"sourceUrl\": \"https://github.com/SAP/openui5\" }"
+                "{ \"releases\": $distinct($filter($each($, function($value){ return { \"version\": $value.version, \"isStable\": $value.lts, \"changelogUrl\": $value.('https://sdk.openui5.org/' & version & '/#releasenotes.html'), \"sourceUrl\": $value.('https://github.com/SAP/openui5/tree/' & version & '/')}}), function($f){$f.isStable})), \"homepage\": \"https://sdk.openui5.org/\", \"changelogUrl\": \"https://sdk.openui5.org/#releasenotes.html\", \"sourceUrl\": \"https://github.com/SAP/openui5\" }"
             ]
         },
         "sapui5": {


### PR DESCRIPTION
In the transformTemplates logic for datasource openui5_lts a ')' was missed resulting in a validation error in the renovate logs.
<img width="1066" alt="Screenshot 2025-04-17 at 08 59 45" src="https://github.com/user-attachments/assets/390f53fc-3569-455a-9f1e-2f38801f3791" />

