### PR TITLE
ci(release-please.yml): Create and update major and minor tags after creating a new release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,3 +17,23 @@ jobs:
       id: release
       with:
         token: ${{secrets.GH_OPENUI5BOT}}
+  publish-package:
+    needs: pull-request
+    if: ${{needs.pull-request.outputs.releases_created && toJson(fromJson(needs.pull-request.outputs.paths_released)) != '[]'}}
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+    - name: tag major and minor versions
+      if: ${{ steps.release.outputs.release_created }}
+      run: |
+        git config user.name "OpenUI5 Bot"
+        git config user.email openui5bot@users.noreply.github.com
+        git tag -d v${{ steps.release.outputs.major }} || true
+        git tag -d v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} || true
+        git push origin :v${{ steps.release.outputs.major }} || true
+        git push origin :v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} || true
+        git tag -a v${{ steps.release.outputs.major }} -m "Release v${{ steps.release.outputs.major }}"
+        git tag -a v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} -m "Release v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}"
+        git push origin v${{ steps.release.outputs.major }}
+        git push origin v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}


### PR DESCRIPTION
If we are releasing a new release e.g. `v1.2.3`, we will also want to update tags `v1` and `v1.2`.
This allows your users to pin to `v1` and `v1.2`, and get updates without updating their renovate config.

Inspired by https://github.com/googleapis/release-please-action?tab=readme-ov-file#creating-majorminor-tags.
